### PR TITLE
Removed whitespace from package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ultimate-hot-reloading-example ",
+  "name": "ultimate-hot-reloading-example",
   "version": "1.0.0",
   "private": true,
   "description": "React example",


### PR DESCRIPTION
First off, cool project! I tried to use `yarn` instead of `npm install` but yarn complained with an error that said:
```
error ultimate-hot-reloading-example @1.0.0: Name contains illegal characters
```
Looks like it was just the additional whitespace at the end of the name it didn't like. I removed it and verified `yarn` does work properly with name not having an extra space at the end. 

It's a really small PR (I don't think they get smaller than one character), but I figured it would help out those in the future trying to explore the project that might be using yarn instead of npm. 